### PR TITLE
feat: Enhance GraphQL queries with additional fields for transfer details

### DIFF
--- a/src/apollo/query.ts
+++ b/src/apollo/query.ts
@@ -6,25 +6,38 @@ export const GET_TRANSFER = gql`
     transfer(transferId: $transferId) {
       transferId
       transferState
+      baseUseCase
       transactionType
       currency
       amount
+      sourceAmount
+      sourceCurrency
+      conversionType
+      conversionState
       settlementId
+      conversionSettlementBatchID
+      submittedDate
+      conversionSubmittedDate
       createdAt
       quoteId
       partyLookupEvents
       quoteEvents
       transferEvents
       settlementEvents
+      transferSettlementBatchID
+      fxp
+      fxpProxy
       payeeDFSP {
         id
         name
         description
+        proxy
       }
       payerDFSP {
         id
         name
         description
+        proxy
       }
       payerParty {
         id
@@ -43,6 +56,43 @@ export const GET_TRANSFER = gql`
         dateOfBirth
         idType
         idValue
+      }
+      transferTerms {
+        quoteAmount
+        quoteAmountType
+        transferAmount
+        payeeReceiveAmount
+        payeeFspFee
+        payeeFspCommission
+        expirationDate
+        geoCode
+        ilpPacket
+        transactionId
+      }
+      conversions {
+        conversionRequestId
+        conversionId
+        conversionCommitRequestId
+        conversionState
+        conversionStateChanges
+        counterPartyFSP
+        conversionSettlementWindowId
+      }
+      conversionTerms {
+        conversionId
+        determiningTransferId
+        initiatingFsp
+        counterPartyFsp
+        amountType
+        transferAmount
+        expiration
+        charges
+      }
+      fxQuotes {
+        Amount
+      }
+      fxTransfers {
+        Amount
       }
     }
   }
@@ -111,6 +161,43 @@ export const GET_TRANSFERS_WITH_EVENTS = gql`
         dateOfBirth
         idType
         idValue
+      }
+      transferTerms {
+        quoteAmount
+        quoteAmountType
+        transferAmount
+        payeeReceiveAmount
+        payeeFspFee
+        payeeFspCommission
+        expirationDate
+        geoCode
+        ilpPacket
+        transactionId
+      }
+      conversions {
+        conversionRequestId
+        conversionId
+        conversionCommitRequestId
+        conversionState
+        conversionStateChanges
+        counterPartyFSP
+        conversionSettlementWindowId
+      }
+      conversionTerms {
+        conversionId
+        determiningTransferId
+        initiatingFsp
+        counterPartyFsp
+        amountType
+        transferAmount
+        expiration
+        charges
+      }
+      fxQuotes {
+        Amount
+      }
+      fxTransfers {
+        Amount
       }
     }
   }


### PR DESCRIPTION
feat: Enhance GraphQL queries with additional fields for transfer details

- Updated `GET_TRANSFER` and `GET_TRANSFERS_WITH_EVENTS` queries to include new fields such as `transferTerms`, `conversions`, `conversionTerms`, `fxQuotes`, and `fxTransfers`.


Changes in:
- `src/apollo/query.ts` (startLine: 4, endLine: 243)
